### PR TITLE
feat(ui): make position of window configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/bafa.nvim',
-  version = 'v1.4.1',
+  version = 'v1.5.0',
+
+  ---@type BafaUserConfig
   opts = {}
 },
 ```
@@ -93,7 +95,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/bafa.nvim',
-  tag = 'v1.4.1',
+  tag = 'v1.5.0',
   config = function()
     require('bafa').setup({})
   end
@@ -109,7 +111,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/bafa.nvim.git',
-  version = 'v1.4.1',
+  version = 'v1.5.0',
 })
 require('bafa').setup({})
 ```
@@ -122,6 +124,7 @@ require('bafa').setup({})
 ### Configuration options
 
 ```lua
+---@type BafaUserConfig
 return {
     title = "Bafa",
     title_pos = "center",
@@ -141,14 +144,25 @@ return {
         },
     },
     hl = {
-        modified = "DiffChange", -- Highlight group for modified buffer text (fallback: GitSignsChange, WarningMsg)
         sign = {
-            modified = "GitSignsChange", -- Highlight group for modified buffer signs (fallback: DiffChange)
-            deleted = "GitSignsDelete", -- Highlight group for deleted buffer signs (fallback: DiffDelete)
+            modified = "DiffChange", -- Highlight group for modified buffer signs
+            deleted = "DiffDelete", -- Highlight group for deleted buffer signs
         },
     },
     notify = {
         provider = "notify", -- "notify" or "print"
+    },
+    ui = {
+        position = {
+            -- Window position preset:
+            "center", "top-center", "bottom-center", "top-left", "top-right",
+            "bottom-left", "bottom-right", "center-left", "center-right"
+            preset = "center",
+            -- Custom row position (overrides preset if set)
+            row = nil,
+            -- Custom column position (overrides preset if set)
+            col = nil,
+        },
     },
 }
 

--- a/lua/bafa/config/init.lua
+++ b/lua/bafa/config/init.lua
@@ -29,7 +29,6 @@ M.config_defaults = {
   line_numbers = false,
   log_level = Types.BafaLoggerLogLevelNames.error,
   hl = {
-    modified = "DiffChange", -- Highlight group for modified buffer text (fallback: GitSignsChange, WarningMsg)
     sign = {
       modified = "GitSignsChange", -- Highlight group for modified buffer signs (fallback: DiffChange)
       deleted = "GitSignsDelete", -- Highlight group for deleted buffer signs (fallback: DiffDelete)
@@ -49,6 +48,13 @@ M.config_defaults = {
       changes = "┃", -- Sign character for modified/deleted buffers (gitsigns-like UX)
     },
   },
+  ui = {
+    position = {
+      preset = Types.BafaConfigWindowPosition.center,
+      row = nil, -- Custom row position (overrides preset if set)
+      col = nil, -- Custom column position (overrides preset if set)
+    },
+  },
 }
 
 ---@type BafaDefaultConfig
@@ -57,8 +63,9 @@ M.user_config = M.config_defaults
 ---Setup configuration
 ---@param config BafaUserConfig|nil
 M.setup = function(config)
-  local normalized_config = M.get_normalized_config(config or {})
-  M.user_config = vim.tbl_deep_extend("force", M.config_defaults, normalized_config)
+  -- Merge user config with defaults using deep extend
+  -- This properly handles nested tables like ui.position
+  M.user_config = vim.tbl_deep_extend("force", M.config_defaults, config or {})
 end
 
 ---Set configuration options

--- a/lua/bafa/types/init.lua
+++ b/lua/bafa/types/init.lua
@@ -57,6 +57,19 @@ M.BafaConfigNotifyProvider = {
   print = "print",
 }
 
+---@enum BafaConfigWindowPosition
+M.BafaConfigWindowPosition = {
+  center = "center",
+  top_center = "top-center",
+  bottom_center = "bottom-center",
+  top_left = "top-left",
+  top_right = "top-right",
+  bottom_left = "bottom-left",
+  bottom_right = "bottom-right",
+  center_left = "center-left",
+  center_right = "center-right",
+}
+
 ---@class BafaPersistedData
 ---@field buffers BafaBuffer[]
 ---@field sorting BafaSorting
@@ -82,8 +95,15 @@ M.BafaConfigNotifyProvider = {
 ---@field deleted string Highlight group for deleted buffer signs
 
 ---@class BafaConfigHl
----@field modified string Highlight group for modified buffer text
 ---@field sign BafaConfigHlSign Highlight groups for signs
+
+---@class BafaConfigUiPosition
+---@field preset BafaConfigWindowPosition|nil Window position preset
+---@field row number|nil Custom row position (overrides preset if set)
+---@field col number|nil Custom column position (overrides preset if set)
+
+---@class BafaConfigUi
+---@field position BafaConfigUiPosition Window position configuration
 
 ---@class BafaDefaultConfig
 ---@field title string
@@ -96,14 +116,22 @@ M.BafaConfigNotifyProvider = {
 ---@field notify BafaConfigNotify
 ---@field icons BafaConfigIcons
 ---@field hl BafaConfigHl Highlight groups configuration
+---@field ui BafaConfigUi UI configuration
 
 ---@class BafaUserConfigHlSign
 ---@field modified string|nil
 ---@field deleted string|nil
 
 ---@class BafaUserConfigHl
----@field modified string|nil
 ---@field sign BafaUserConfigHlSign|nil
+
+---@class BafaUserConfigUiPosition
+---@field preset BafaConfigWindowPosition|nil Window position preset
+---@field row number|nil Custom row position (overrides preset if set)
+---@field col number|nil Custom column position (overrides preset if set)
+
+---@class BafaUserConfigUi
+---@field position BafaUserConfigUiPosition|nil Window position configuration
 
 ---@class BafaUserConfig
 ---@field title string|nil
@@ -116,6 +144,7 @@ M.BafaConfigNotifyProvider = {
 ---@field notify BafaConfigNotify|nil
 ---@field icons BafaConfigIcons|nil
 ---@field hl BafaUserConfigHl|nil
+---@field ui BafaUserConfigUi|nil
 
 ---@class BafaState
 ---@field sorting BafaSorting|nil


### PR DESCRIPTION
Added a UI attribute to the config:

```lua
---@class BafaConfigUi
---@field position BafaConfigUiPosition Window position configuration

---@class BafaConfigUiPosition
---@field preset BafaConfigWindowPosition|nil Window position preset
---@field row number|nil Custom row position (overrides preset if set)
---@field col number|nil Custom column position (overrides preset if set)

---@enum BafaConfigWindowPosition
M.BafaConfigWindowPosition = {
  center = "center",
  top_center = "top-center",
  bottom_center = "bottom-center",
  top_left = "top-left",
  top_right = "top-right",
  bottom_left = "bottom-left",
  bottom_right = "bottom-right",
  center_left = "center-left",
  center_right = "center-right",
}
```
Also fixed an issue which prevented the user config to be merged.