### PR TITLE
feat(ui): add opts to toggle() -> with_jump_labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/bafa.nvim',
-  version = 'v1.7.1',
+  version = 'v1.8.0',
 },
 ```
 
@@ -88,7 +88,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/bafa.nvim',
-  tag = 'v1.7.1',
+  tag = 'v1.8.0',
 })
 ```
 
@@ -97,7 +97,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/bafa.nvim.git',
-  version = 'v1.7.1',
+  version = 'v1.8.0',
 })
 require('bafa').setup()
 ```
@@ -203,6 +203,17 @@ return {
 Opens up a floating window with your buffers.
 
 The buffers are ordered by last usage time by default.
+
+Optionally accepts a table of "instructions"
+to pre-configure the UI state.
+
+```lua
+require('bafa.ui').toggle({
+    -- Show jump-labels when opening the UI
+    -- defaults to false|nil
+    with_jump_labels = true,
+})
+```
 
 ### Switching to a buffer
 

--- a/lua/bafa/types/init.lua
+++ b/lua/bafa/types/init.lua
@@ -70,6 +70,9 @@ M.BafaConfigWindowPosition = {
   center_right = "center-right",
 }
 
+---@class BafaUiToggleOptions
+---@field with_jump_labels boolean|nil If true, shows jump labels when opening the menu
+
 ---@class BafaPersistedData
 ---@field buffers BafaBuffer[]
 ---@field sorting BafaSorting

--- a/lua/bafa/ui.lua
+++ b/lua/bafa/ui.lua
@@ -1598,8 +1598,12 @@ function M.toggle_sorting(sorting)
 end
 
 ---Toggle bafa menu
+---@param opts BafaUiToggleOptions|nil Optional options
 ---@returns nil
-function M.toggle()
+function M.toggle(opts)
+  opts = opts or {}
+  if opts.with_jump_labels == true then jump_labels_visible = true end
+
   if BAFA_WIN_ID ~= nil and vim.api.nvim_win_is_valid(BAFA_WIN_ID) then
     close_window()
     -- Restore cursor when closing the window


### PR DESCRIPTION
toggle() can be called with an optional options table now.

```lua
require('bafa.ui').toggle({
    -- Show jump-labels when opening the UI
    -- defaults to false|nil
    with_jump_labels = true,
})
```