### PR TITLE
fix/(keymaps): toggle sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/bafa.nvim',
-  version = 'v1.8.0',
+  version = 'v1.8.1',
 },
 ```
 
@@ -88,7 +88,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/bafa.nvim',
-  tag = 'v1.8.0',
+  tag = 'v1.8.1',
 })
 ```
 
@@ -97,7 +97,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/bafa.nvim.git',
-  version = 'v1.8.0',
+  version = 'v1.8.1',
 })
 require('bafa').setup()
 ```
@@ -124,17 +124,19 @@ return {
       -- in order of preference
       -- Should be unique characters
       -- Duplicates will be ignored
+      -- require('bafa.utils.keys').protected_jump_label_keys
+      -- are also protected and will be ignored
       -- You can customize this to your keyboard layout
       -- will also use uppercase variants of these keys
       -- if the lower-case ones are exhausted
-      -- This should give us 48 unique keys on a QWERTY layout
+      -- This should give us roughly 46 unique keys (minus the protected ones)
       -- That should be enough for most use-cases
       -- but when we run out of keys, only the first buffers (in order, from top to bottom)
       -- will get jump-labels assigned
       keys = {
         "a", "s", "d", "f", "j", "k", "l", ";",
         "q", "w", "e", "r", "u", "i", "o", "p",
-        "z", "x", "c", "v", "n", "m", ",", ".",
+        "z", "x", "c", "n", "m", ",", ".",
       }
     },
     -- 🚨 Show diagnostics in the UI

--- a/lua/bafa/config/init.lua
+++ b/lua/bafa/config/init.lua
@@ -33,7 +33,7 @@ M.config_defaults = {
       keys = {
         "a", "s", "d", "f", "j", "k", "l", ";",
         "q", "w", "e", "r", "u", "i", "o", "p",
-        "z", "x", "c", "v", "n", "m", ",", ".",
+        "z", "x", "c", "n", "m", ",", ".",
       },
     },
     diagnostics = true,

--- a/lua/bafa/ui.lua
+++ b/lua/bafa/ui.lua
@@ -920,6 +920,7 @@ end
 ---@param pass_through boolean|nil If true, passes through the keypress to jump labels
 function M.cancel_action_handler(pass_through)
   if BAFA_WIN_ID == nil or not vim.api.nvim_win_is_valid(BAFA_WIN_ID) then return end
+  -- If jump labels are visible, ignore cancel unless pass_through is true
   if jump_labels_visible then
     if pass_through then return end
     M.hide_jump_labels()
@@ -1001,6 +1002,7 @@ end
 ---Deletes selected buffers in visual mode, or single buffer in normal mode
 ---@returns nil
 function M.delete_menu_item()
+  -- If jump labels are visible and delete action is pending, use jump label deletion
   if jump_labels_visible and pending_jump_label_action ~= "delete" then
     M.setup_delete_by_label()
     return
@@ -1106,10 +1108,8 @@ end
 ---Supports visual selection: moves selected range as a block
 ---@returns nil
 function M.move_buffer_up()
-  if jump_labels_visible then
-    -- If jump labels are visible, ignore move commands
-    return
-  end
+  -- If jump labels are visible, ignore and fallthrough
+  if jump_labels_visible then return end
   if BAFA_WIN_ID == nil or not vim.api.nvim_win_is_valid(BAFA_WIN_ID) then return end
   if BAFA_BUF_ID == nil or not vim.api.nvim_buf_is_valid(BAFA_BUF_ID) then return end
 
@@ -1178,10 +1178,8 @@ end
 ---Supports visual selection: moves selected range as a block
 ---@returns nil
 function M.move_buffer_down()
-  if jump_labels_visible then
-    -- If jump labels are visible, ignore move commands
-    return
-  end
+  -- If jump labels are visible, ignore and fallthrough
+  if jump_labels_visible then return end
 
   if BAFA_WIN_ID == nil or not vim.api.nvim_win_is_valid(BAFA_WIN_ID) then return end
   if BAFA_BUF_ID == nil or not vim.api.nvim_buf_is_valid(BAFA_BUF_ID) then return end
@@ -1553,10 +1551,8 @@ end
 ---Undoes last change
 ---@returns nil
 function M.undo()
-  if jump_labels_visible then
-    -- skip undo while jump labels are visible
-    return
-  end
+  -- If jump labels are visible, ignore and fallthrough
+  if jump_labels_visible then return end
   if State.undo() then refresh_ui() end
 end
 
@@ -1564,10 +1560,8 @@ end
 --.Redoes last undone change
 --@returns nil
 function M.redo()
-  if jump_labels_visible then
-    -- skip redo while jump labels are visible
-    return
-  end
+  -- If jump labels are visible, ignore and fallthrough
+  if jump_labels_visible then return end
   if State.redo() then refresh_ui() end
 end
 
@@ -1580,6 +1574,8 @@ function M.refresh_ui() refresh_ui() end
 ---@param sorting BafaSorting|nil Optional sorting mode to set (manual/auto). If nil, toggles between modes.
 ---@returns nil
 function M.toggle_sorting(sorting)
+  -- If jump labels are visible, ignore and fallthrough
+  if jump_labels_visible then return end
   local current_sorting_mode = State.get_persisted_sorting()
   if current_sorting_mode == Types.BafaSorting.AUTO and (sorting == nil or sorting == Types.BafaSorting.MANUAL) then
     Logger.notify("Sorting set to: " .. Types.BafaSorting.MANUAL, Logger.INFO)

--- a/lua/bafa/utils/keys.lua
+++ b/lua/bafa/utils/keys.lua
@@ -5,15 +5,13 @@ local M = {}
 M.localleader = vim.g.maplocalleader or vim.g.mapleader
 
 ---List of reserved keys that cannot be used as jump labels
+---and will be skipped when generating jump labels
 ---@type string[]
 M.protected_jump_label_keys = {
-  "J", -- move down
-  "K", -- move up
-  "u", -- undo
   "g", -- used to toggle jump labels
   "d", -- this enables deleting buffers
-  "V", -- line visual mode
-  "v", -- visual mode
+  "v", -- used for visual mode
+  "V", -- used for visual line mode
 }
 
 if M.localleader then table.insert(M.protected_jump_label_keys, M.localleader) end


### PR DESCRIPTION
also make the mapping simply fall through in most cases when jump labels are active.

this reduces the procteted keys by quite a margin.