### PR TITLE
feat(ui): add ft to ui buffer (`bafa`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/bafa.nvim',
-  version = 'v1.10.1',
+  version = 'v1.11.0',
 },
 ```
 
@@ -89,7 +89,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/bafa.nvim',
-  tag = 'v1.10.1',
+  tag = 'v1.11.0',
 })
 ```
 
@@ -98,7 +98,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/bafa.nvim.git',
-  version = 'v1.10.1',
+  version = 'v1.11.0',
 })
 require('bafa').setup()
 ```

--- a/lua/bafa/config/init.lua
+++ b/lua/bafa/config/init.lua
@@ -9,6 +9,9 @@ M.get_normalized_config = function(cfg) return vim.tbl_deep_extend("force", M.co
 ---@type string
 M.plugin_name = "bafa.nvim"
 
+---@type string
+M.ui_buffer_ft = "bafa"
+
 ---@type BafaDefaultConfig
 M.config_defaults = {
   log_level = Types.BafaLoggerLogLevelNames.error,

--- a/lua/bafa/ui.lua
+++ b/lua/bafa/ui.lua
@@ -1700,6 +1700,7 @@ function M.toggle(opts)
   local ui_config = bafa_config.ui or {}
   vim.wo[BAFA_WIN_ID].number = ui_config.line_numbers or false
   vim.api.nvim_buf_set_name(BAFA_BUF_ID, "bafa://bafa-menu")
+  vim.bo[BAFA_BUF_ID].filetype = Config.ui_buffer_ft
   vim.bo[BAFA_BUF_ID].buftype = "nofile"
   vim.bo[BAFA_BUF_ID].bufhidden = "delete"
 


### PR DESCRIPTION
So something like this should be possible now:

```lua
vim.api.nvim_create_autocmd('FileType', {
  group = vim.api.nvim_create_augroup('userautocmd-bafa', { clear = true }),
  pattern = 'bafa',
  callback = function()
    vim.keymap.set('n', 'l', '<CR>', { remap = true, buffer = true, desc = 'Select' })
  end,
})

return {
  "mistweaverco/bafa.nvim",
  opts = {
    ui = {
      jump_labels = {
        -- Keys to use for jump-labels
        -- they are reserved and because `l` is in the defaults, we need
        -- to supply a table without the reserved `l` key
        keys = {
          "a",
          "s",
          "d",
          "f",
          "j",
          "k",
          ";",
          "q",
          "w",
          "e",
          "r",
          "u",
          "i",
          "o",
          "p",
          "z",
          "x",
          "c",
          "n",
          "m",
          ",",
          ".",
        },
      },
    },
  },
}
```