### PR TITLE
fix(plugin): replace deprecated BufModifiedSet with Optionset modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See: [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'mistweaverco/bafa.nvim',
-  version = 'v1.12.0',
+  version = 'v1.12.1',
 },
 ```
 
@@ -89,7 +89,7 @@ See: [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
   'mistweaverco/bafa.nvim',
-  tag = 'v1.12.0',
+  tag = 'v1.12.1',
 })
 ```
 
@@ -98,7 +98,7 @@ use {
 ```lua
 vim.pack.add({
   src = 'https://github.com/mistweaverco/bafa.nvim.git',
-  version = 'v1.12.0',
+  version = 'v1.12.1',
 })
 require('bafa').setup()
 ```

--- a/lua/bafa/utils/autocmds.lua
+++ b/lua/bafa/utils/autocmds.lua
@@ -2,7 +2,15 @@ local M = {}
 
 function M.defaults(bufnr)
   vim.cmd(string.format("autocmd BufWriteCmd <buffer=%s> lua require('bafa.ui').on_menu_save()", bufnr))
-  vim.cmd(string.format("autocmd BufModifiedSet <buffer=%s> set nomodified", bufnr))
+  -- replace deprecated BufModifiedSet with Optionset modified:
+  -- https://github.com/mistweaverco/bafa.nvim/issues/59
+  -- https://github.com/neovim/neovim/commit/443171328531e33a7caecda0b81dadd826518a58
+  -- neovim 0.12+ deprecated BufModifiedSet, use Optionset modified instead
+  if vim.fn.has("nvim-0.12") == 1 then -- reports 1 if nvim version is 0.12 or higher
+    vim.cmd(string.format("autocmd OptionSet modified <buffer=%s> set nomodified", bufnr))
+  else
+    vim.cmd(string.format("autocmd BufModifiedSet <buffer=%s> set nomodified", bufnr))
+  end
   vim.cmd("autocmd BufLeave <buffer> ++nested ++once silent lua require('bafa.ui').toggle()")
 end
 


### PR DESCRIPTION
https://github.com/mistweaverco/bafa.nvim/issues/59 https://github.com/neovim/neovim/commit/443171328531e33a7caecda0b81dadd826518a58

neovim 0.12+ deprecated BufModifiedSet, use Optionset modified instead